### PR TITLE
Removed in_thread option (Not ready)

### DIFF
--- a/.github/workflows/discord_notifications.yml
+++ b/.github/workflows/discord_notifications.yml
@@ -13,4 +13,4 @@ jobs:
         with:
           id: ${{ secrets.DISCORD_WEBHOOK_ID }}
           token: ${{ secrets.DISCORD_WEBHOOK_TOKEN }}
-          in_thread: ${{ secrets.DISCORD_INTHREAD }}
+          #in_thread: ${{ secrets.DISCORD_INTHREAD }}


### PR DESCRIPTION

<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
[see here for further details](https://github.blog/2019-02-14-introducing-draft-pull-requests/).

Before submitting a Pull Request, please ensure you've done the following:
- [📖 Read the Contributing Guide](https://github.com/thomasbnt/awesome-web-monetization/blob/master/contributing.md).
- [📖 Read Code of Conduct](https://github.com/thomasbnt/awesome-web-monetization/blob/master/code-of-conduct.md).
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation.
-->

## What type of PR is this? (check all applicable)

- [ ] Adding new(s) resource(s)
    - Else : 
	- [ ] Added icon to right of the link 
	- [ ] Checking if the resource is not already written
- [ ] Update About Web Monetization part
- [ ] Update asset(s)
    - Else :
    - [ ] Height is **16px**
    - [ ] Format is **png**
- [x] GitHub Action 

## Description
<!-- 
A clear description of your PR. 

-->
Because the GitHub Action isn't ready, in_thread option is removed for the moment.

## Related Issues and/or Documents

<!-- 
For new sources, you don't need to fill out this part.

For the updated part of "About Web Monetization", fill in this part with the sources where you retrieved the information.

-->
Concern this GitHub Actions : https://github.com/Mist3r-Robot/classic-discord-webhook